### PR TITLE
修改：continue提前结束`内`层循环

### DIFF
--- a/articles/control-flows.html
+++ b/articles/control-flows.html
@@ -706,7 +706,7 @@ Exit:
 一个<code>goto</code>语句必须包含一个跳转标签名。
 一个<code>break</code>或者<code>continue</code>语句也可以包含一个跳转标签名，但此跳转标签名是可选的。
 包含跳转标签名的<code>break</code>语句一般用于可跳出外层的嵌套可跳出流程控制代码块。
-包含跳转标签名的<code>continue</code>语句一般用于提前结束外层的嵌套循环流程控制代码块。
+包含跳转标签名的<code>continue</code>语句一般用于提前结束内层的嵌套循环流程控制代码块。
 </p>
 
 <p>


### PR DESCRIPTION
我的理解是：continue是提前结束内层的循环。举个栗子：
```
label:
	for i := 0; i < 10; i++ {
		for j := 11; j < 20; j++ {
			if j == 15 {
				continue label
			}
		}
	}
}
```
此时内层只会循环5次，就因为continue结束了。
但是外层还是会执行10次循环。
因此我认为这里的应该是提前结束内层循环的代码。